### PR TITLE
Precompile regexes to improve performance

### DIFF
--- a/detect_test.go
+++ b/detect_test.go
@@ -61,6 +61,17 @@ func TestPowerPC3(t *testing.T) {
 	assert.Equal(t, MustExamine("testdata/nc_e500v2"), "unknown")
 }
 
+var doNotOptimiseString string
+func BenchmarkVoidLinux(b *testing.B) {
+	b.ReportAllocs()
+
+	var result string
+        for n := 0; n < b.N; n++ {
+		result = MustExamine("testdata/nano_voidlinux")
+        }
+	doNotOptimiseString = result
+}
+
 func TestVersionCompare(t *testing.T) {
 	assert.Equal(t, FirstIsGreater("2", "1.0.7.abc"), true)
 	assert.Equal(t, FirstIsGreater("2.0", "2.0 alpha1"), true)


### PR DESCRIPTION
Trade-off a bit of initial work that might not ever be necessary for significant improvements. What prompted me to look into the code was that `xyproto/ainur` showed up in the CPU profiles for the application I work on.

We love `ainur`, thanks so much for it! And we call it very often. So much that we spend ~7% of our CPU cycles repeatedly building the regex. While we might add some caching here to call this less frequently, thought it would be worth making it faster, too.

Test Plan
=========

Added a simple benchmark in `detect_test.go`, which can be run with:

```
$ go test -bench=. -count=30 > <new/old>.txt
```

```
$ benchstat old.txt new.txt
name          old time/op    new time/op    delta
VoidLinux-12     145µs ± 7%     104µs ± 7%  -28.28%  (p=0.000 n=28+30)

name          old alloc/op   new alloc/op   delta
VoidLinux-12    97.4kB ± 0%    72.6kB ± 0%  -25.46%  (p=0.000 n=29+30)

name          old allocs/op  new allocs/op  delta
VoidLinux-12       401 ± 0%       196 ± 0%  -51.12%  (p=0.000 n=30+30)
```

This commit reduces the time and allocated memory by slightly more than 25%. The metric that improved the most is the allocations per operation, halving it.

```
$ go test .
ok  	github.com/xyproto/ainur	0.007s
```

Looking forward to your feedback and I would totally understand if you would rather not accept this change :).

Signed-off-by: Francisco Javier Honduvilla Coto <javierhonduco@gmail.com>