### PR TITLE
Faster Stripped

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -367,8 +367,7 @@ func Compiler(f *elf.File) string {
 
 // Stripped returns true if symbols can not be retrieved from the given ELF file
 func Stripped(f *elf.File) bool {
-	_, err := f.Symbols()
-	return err != nil
+	return f.SectionByType(elf.SHT_SYMTAB) == nil
 }
 
 // Examine tries to discover which compiler and compiler version the given


### PR DESCRIPTION
in parca agent https://github.com/parca-dev/parca-agent/blob/main/pkg/metadata/compiler.go#L85.
we should get every process if it is stripped.
so we should reduce the stripped function memory allocation and time cost.